### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   jest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alexwintle/recipme/security/code-scanning/4](https://github.com/alexwintle/recipme/security/code-scanning/4)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only requires read access to repository contents, the permissions can be set to `contents: read`. This ensures that the `GITHUB_TOKEN` has the minimal privileges necessary to complete the workflow tasks.

The `permissions` block should be added at the root level of the workflow file, as this will apply to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
